### PR TITLE
Cambio en "delete:" del endpoint "/user/gallery:"

### DIFF
--- a/Recursos/Postman/Consultor Películas y Series API.postman_collection.json
+++ b/Recursos/Postman/Consultor Películas y Series API.postman_collection.json
@@ -1,6 +1,6 @@
 {
 	"info": {
-		"_postman_id": "34f4a365-ed0c-4470-ac6c-fc18f291a143",
+		"_postman_id": "0dc53a5f-87cc-47ca-8fac-8ca678126d6e",
 		"name": "Consultor Películas y Series API",
 		"schema": "https://schema.getpostman.com/json/collection/v2.0.0/collection.json",
 		"_exporter_id": "40985364"
@@ -100,11 +100,27 @@
 								"value": "Bearer {{token}}"
 							}
 						],
-						"body": {
-							"mode": "raw",
-							"raw": "{\n  \"id\": 603,\n  \"media_type\": \"movie\"\n}"
-						},
-						"url": "{{BASE_URL_BACKEND}}/api/user/gallery"
+						"url": {
+							"raw": "{{BASE_URL_BACKEND}}/api/user/gallery?id=603&media_type=movie",
+							"host": [
+								"{{BASE_URL_BACKEND}}"
+							],
+							"path": [
+								"api",
+								"user",
+								"gallery"
+							],
+							"query": [
+								{
+									"key": "id",
+									"value": "603"
+								},
+								{
+									"key": "media_type",
+									"value": "movie"
+								}
+							]
+						}
 					},
 					"response": []
 				}
@@ -338,18 +354,26 @@
 			]
 		}
 	],
-	"variable": [
+	"event": [
 		{
-			"key": "base_url",
-			"value": "http://localhost:5000"
+			"listen": "prerequest",
+			"script": {
+				"type": "text/javascript",
+				"packages": {},
+				"exec": [
+					""
+				]
+			}
 		},
 		{
-			"key": "token",
-			"value": ""
-		},
-		{
-			"key": "comment_id",
-			"value": ""
+			"listen": "test",
+			"script": {
+				"type": "text/javascript",
+				"packages": {},
+				"exec": [
+					""
+				]
+			}
 		}
 	]
 }

--- a/consultorpeliculasyseries/backend/src/controllers/usersAndAuthController.js
+++ b/consultorpeliculasyseries/backend/src/controllers/usersAndAuthController.js
@@ -90,8 +90,8 @@ const getUserGallery = async (req, res) => {
 const deleteFromGallery = async (req, res) => {
     try {
         const userId = req.user.id;
-        const { id, media_type } = req.body;
-        const result = await Gallery.findOneAndDelete({ userId, id, media_type });
+        const { id, media_type } = req.query;
+        const result = await Gallery.findOneAndDelete({ userId, id: Number(id), media_type });
         if (!result) {
             return res.status(404).json({ msg: 'No se encontró el elemento en tu galería' });
         }

--- a/consultorpeliculasyseries/backend/src/openapi/openapi.yaml
+++ b/consultorpeliculasyseries/backend/src/openapi/openapi.yaml
@@ -87,17 +87,15 @@ paths:
       summary: Eliminar contenido de la galería
       security:
         - bearerAuth: []
-      requestBody:
-        required: true
-        content:
-          application/json:
-            schema:
-              type: object
-              properties:
-                id:
-                  type: number
-                media_type:
-                  type: string
+      parameters:
+        - in: query
+          name: id
+          schema:
+            type: number
+        - in: query
+          name: media_type
+          schema:
+            type: string
       responses:
         '200':
           description: Eliminado correctamente

--- a/consultorpeliculasyseries/backend/tests/e2e/gallery.e2e.test.js
+++ b/consultorpeliculasyseries/backend/tests/e2e/gallery.e2e.test.js
@@ -111,10 +111,11 @@ describe('Gallery Endpoints', () => {
                 overview: 'Test Overview',
                 poster_path: '/test.jpg'
             });
+        // Envía los datos como query params, no como body
         const res = await request(app)
             .delete('/api/user/gallery')
             .set('Authorization', `Bearer ${token}`)
-            .send({ id: 123, media_type: 'movie' });
+            .query({ id: 123, media_type: 'movie' });
         expect(res.statusCode).toBe(200);
     });
 });

--- a/consultorpeliculasyseries/frontend/src/components/GalleryButton/GalleryButtonService.js
+++ b/consultorpeliculasyseries/frontend/src/components/GalleryButton/GalleryButtonService.js
@@ -30,18 +30,12 @@ async function addToGallery({ id, media_type, title, overview, image_url }) {
 }
 // Elimina un contenido de la galería del usuario
 async function removeFromGallery(id, media_type) {
-    const res = await fetch(`${BASE_URL}/api/user/gallery`, {
+    const res = await fetch(`${BASE_URL}/api/user/gallery?id=${id}&media_type=${media_type}`, {
         method: "DELETE",
-        headers: {
-            "Content-Type": "application/json",
-            ...UtilsService.getAuthHeaders()
-        },
-        body: JSON.stringify({ id, media_type })
+        headers: { ...UtilsService.getAuthHeaders() }
     });
-    if (!res.ok) {
-        const data = await res.json().catch(() => ({}));
-        throw new Error(data.msg || data.message || "No se pudo eliminar de tu galería");
-    }
+    if (!res.ok) throw new Error("No se pudo eliminar de la galería");
+    return await res.json();
 }
 // Comprueba si un contenido(pelicula/serie) está en la galería del usuario
 async function checkIfInGallery(id, media_type) {


### PR DESCRIPTION
Se ha cambiado la forma en que se envían los datos al eliminar un contenido de la galería, antes se enviaban dentro del cuerpo de la petición "requestBody" en formato JSON, y ahora  los datos se envían como parámetros en la URL, también se ha actualizado la colección de Postman